### PR TITLE
#80 0523 10:45 캘린더 dot 표시 백엔드 연동

### DIFF
--- a/react/src/pages/Mypage/Mypage.jsx
+++ b/react/src/pages/Mypage/Mypage.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import Calendar from 'react-calendar';
 import 'react-calendar/dist/Calendar.css';
-import { data, Link } from "react-router-dom";
+import { Link } from "react-router-dom";
 import '../../assets/styles/MyCalendar.css';
 import styles from "../../assets/styles/Mypage.module.css";
 import calStyles from "../../assets/styles/CalendarPage.module.css";
@@ -9,6 +9,9 @@ import MypageNav from "../../components/MypageNavBar/MypageNav";
 import FiveDayForecast from '../Calendar/FiveDayForecast';
 
 function Mypage2() {
+  const token = localStorage.getItem('token');
+  // console.log(token);
+
   // 예시 데이터
   const initialPlans = [
   {
@@ -49,26 +52,36 @@ function Mypage2() {
   useEffect(() => {
     const yearMonth = `${activeStartDate.getFullYear()}-${String(activeStartDate.getMonth()+1).padStart(2,'0')}`;
 
-    fetch(`http://localhost:8080/mypage/dots?userId=test123&yearMonth=${yearMonth}`)
+    fetch(`http://localhost:8080/api/v1/mypage/dots?yearMonth=${yearMonth}`, {
+      headers: {Authorization: `Bearer ${token}`}
+    })
       .then(res => res.json())
-      .then(data => {
-        console.log("dotData 확인:", data); // 데이터 확인
-        setDotData(data);
+      .then(dataArray => {
+        console.log("raw dotData: ", dataArray);
+        // 배열을 {'2025-05-20':'plan',...} 형태의 map으로 변환
+        const map = dataArray.reduce((acc, {date, type}) => {
+          acc[date] = type;
+          return acc;
+        }, {});
+        console.log('mapped dotData:', map)
+        setDotData(map);
       })
       .catch(err => console.error("dot 불러오기 실패", err));
   }, [activeStartDate]);
 
   // 선택된 날짜 변경 시 dailyData 가져오기
-  useEffect(() => {
-    const dateStr = formatDate(value);
-    fetch(`http://localhost:8080/mypage/data?userId=test123&date=${dateStr}`)
-      .then(res => res.json())
-      .then(data => {
-        console.log("dailyData 확인: ", data);
-        setDailyData(data);
-      })
-      .catch(err => console.log("dailyData 불러오기 실패", err));
-  }, [value]);
+  // useEffect(() => {
+  //   const dateStr = formatDate(value);
+  //   fetch(`http://localhost:8080/api/v1/mypage/data?date=${dateStr}`, {
+  //     headers: {Authorization: `Bearer ${token}`}
+  //   })
+  //     .then(res => res.json())
+  //     .then(data => {
+  //       console.log("dailyData 확인: ", data);
+  //       setDailyData(data);
+  //     })
+  //     .catch(err => console.log("dailyData 불러오기 실패", err));
+  // }, [value]);
 
   return (
     <>


### PR DESCRIPTION
## 캘린더 dot 표시 백엔드 연동

## 관련 이슈 (Related Issue)

- Closes #80
- Fixes #80
## 변경 사항 (Changes)

- [ ] 마이페이지 캘린더 dot 표시 백엔드 프론트 연동

## 작업 목적 및 배경 (Purpose/Background)

- 로그인한 사용자가 자신의 일정을 한눈에 파악 가능

## 리뷰 포인트 (Points for Review)

- 마이페이지의 캘린더를 봐주세요.

## 테스트 방법 (How to Test)

1.  **브랜치 체크아웃 (Branch Checkout):**
    * `git checkout view/캘린더백엔드연동`

2.  **필수 명령어 실행 (Run Necessary Commands):**
    * npm run dev

3.  **확인 절차 (Verification Steps):**

        1.  로그인을 합니다.
        2. 마이페이지에 진입합니다.
        3. 마이페이지의 캘린더를 확인합니다.

